### PR TITLE
Add toggle to show all parts in customer view

### DIFF
--- a/frontend/src/components/Customer/Customer.jsx
+++ b/frontend/src/components/Customer/Customer.jsx
@@ -11,6 +11,7 @@ export default function Customer(props) {
   const [markedParts, setMarkedParts] = useState(customer.parts || []);
   const [customPartPrice, setCustomPartPrice] = useState(customer.partPrices || []);
   const [openParts, setOpenParts] = useState(false);
+  const [showAllParts, setShowAllParts] = useState(false);
   const [openSmsModal, setOpenSmsModal] = useState(false);
   const [priceAccepted, setPriceAccepted] = useState(customer.priceAccepted || false);
   const [showButtons, setShowButtons] = useState(false);
@@ -155,6 +156,7 @@ export default function Customer(props) {
               <p>{customer.bikeNumber}</p>
             </div>
 
+            { !customer.partToFix && customer.partToFix.length > 0 && (
             <div className="info-line">
               <h4>Saker att kolla på</h4>
               {
@@ -172,12 +174,16 @@ export default function Customer(props) {
                 })
               }
             </div>
+            )}
 
           </div>
           <div className="parts-container">
             <div className="parts-container-top">
               <h3>Delar</h3>
-              <span onClick={() => { setOpenParts(!openParts) }} className={`${openParts ? "open" : ""}`}><ion-icon name="chevron-down-outline"></ion-icon></span>
+              <div className="right">
+                <span onClick={() => { setShowAllParts(!showAllParts) }} >{showAllParts ? <ion-icon name="close-outline"></ion-icon> : <ion-icon name="pencil-outline"></ion-icon>}</span>
+                <span onClick={() => { setOpenParts(!openParts) }} className={`${openParts ? "open" : ""}`}><ion-icon name="chevron-down-outline"></ion-icon></span>
+              </div>
             </div>
             {openParts && (
               <div className="parts-list">
@@ -192,6 +198,7 @@ export default function Customer(props) {
                         setMarkedParts={setMarkedParts}
                         customPartPrice={customPartPrice}
                         setCustomPartPrice={setCustomPartPrice}
+                        showAllParts={showAllParts}
                       />
                     )
                   })

--- a/frontend/src/components/Customer/Customer.scss
+++ b/frontend/src/components/Customer/Customer.scss
@@ -75,6 +75,11 @@
       .parts-container-top {
         display: flex;
         justify-content: space-between;
+
+        .right {
+          display: flex;
+          gap: 8px;
+        }
       }
 
       .parts-list {

--- a/frontend/src/components/Part/CustomerPart.jsx
+++ b/frontend/src/components/Part/CustomerPart.jsx
@@ -51,12 +51,14 @@ export default function Part(props) {
 
   const markPart = (e) => {
     e.preventDefault();
-    if (marked) {
-      props.setMarkedParts(props.markedParts.filter(id => id !== part._id));
-    } else {
-      props.setMarkedParts([...props.markedParts, part._id]);
+    if (props.showAllParts) {
+      if (marked) {
+        props.setMarkedParts(props.markedParts.filter(id => id !== part._id));
+      } else {
+        props.setMarkedParts([...props.markedParts, part._id]);
+      }
+      setMarked(!marked);
     }
-    setMarked(!marked);
   }
 
   const customPrice = (price) => {
@@ -66,7 +68,19 @@ export default function Part(props) {
     console.log(price);
   }
 
+  const checkMarkedChildren = () => {
+    if (children.length >= 1) {
+      return children.some(child => props.markedParts.includes(child._id));
+    }
+    return false;
+  }
+
+
   if (part.children && part.children.length >= 1) {
+    const markedChildren = checkMarkedChildren();
+    if (!props.showAllParts && !markedChildren) {
+      return null;
+    }
 
     return (
       <div className={"part"}>
@@ -87,6 +101,7 @@ export default function Part(props) {
               setMarkedParts={props.setMarkedParts}
               customPartPrice={props.customPartPrice}
               setCustomPartPrice={props.setCustomPartPrice}
+              showAllParts={props.showAllParts}
               className="child"
             />
           ))}
@@ -94,6 +109,10 @@ export default function Part(props) {
 
       </div >
     )
+  }
+
+  if (!props.showAllParts && !marked) {
+    return;
   }
 
   return (


### PR DESCRIPTION
Introduces a 'showAllParts' state and UI toggle in the Customer component to allow users to view and mark all parts, not just those already marked. Updates CustomerPart logic to conditionally render parts and children based on the toggle, and adjusts styles for the new UI controls.